### PR TITLE
Ckeck for a value in Shib-Identity-Provider header

### DIFF
--- a/Service/Shibboleth.php
+++ b/Service/Shibboleth.php
@@ -86,7 +86,7 @@ class Shibboleth {
     }
 
     public function isAuthenticated(Request $request) {
-        return $request->headers->has('shib-identity-provider');
+        return (bool)$request->headers->get('shib-identity-provider');
     }
 
     public function getUser(Request $request) {


### PR DESCRIPTION
When logged out, the Shib-Identity-Provider header still exists in my environment. So I need to check if it is empty.
