### PR TITLE
Fix casing of logoutURL shibboleth property

### DIFF
--- a/Service/Shibboleth.php
+++ b/Service/Shibboleth.php
@@ -158,7 +158,7 @@ class Shibboleth {
      * Returns URL to invalidate the shibboleth session.
      */
     function getLogoutUrl(Request $request, $return = null) {
-        $logout_redirect = $this->getAttribute($request, 'Shib-Logouturl');
+        $logout_redirect = $this->getAttribute($request, 'Shib-logoutURL');
         if (!empty($logout_redirect)) {
             return $this->getHandlerUrl($request) . '/Logout?return='. urlencode($logout_redirect
                     . (empty($return)? '' : '?return='.$return) );


### PR DESCRIPTION
`Logouturl` does not match cases with `logoutURL`, which causes the attribute request to work with `useHeaders` (because everything is lowercased anyways and headers are case-insensitive). However, when using environment variables, the attribute is undefined, resulting in a logout URL that only executes a local logout and not a full one.