### PR TITLE
Do not conflict with ourself

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,6 @@
             "name": "Bert Van Gelder"
         }
     ],
-    "conflict": {
-        "kuleuven/shibboleth-bundle": "*"
-    },
     "autoload": {
         "psr-4": { "KULeuven\\ShibbolethBundle\\": "" }
     }


### PR DESCRIPTION
Having this package conflict with itself renders it uninstallable.
Fixes al small bug merged from #15 