### PR TITLE
Make bundle compatible with symfony 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This bundle adds a shibboleth authentication provider for your Symfony2 project.
 
 Requirements
 ------------
-* [PHP][@php] 5.3.3 and up.
-* [Symfony 2.1][@symfony]
+* [PHP](http://php.net) 5.3.3 and up.
+* [Symfony 2.2+][http://symfony.com]
 
 Installation
 ------------

--- a/Security/ShibbolethAuthProvider.php
+++ b/Security/ShibbolethAuthProvider.php
@@ -24,6 +24,7 @@
  */
 namespace KULeuven\ShibbolethBundle\Security;
 use KULeuven\ShibbolethBundle\Service\Shibboleth;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -33,7 +34,6 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
 
 class ShibbolethAuthProvider implements AuthenticationProviderInterface {
 


### PR DESCRIPTION
In symfony 3, `Symfony\Component\HttpKernel\Log\LoggerInterface` is removed in favor of `Psr\Log\LoggerInterface`.

The `Psr\Log\LoggerInterface` was first available in symfony 2.2, so this will patch will drop support for symfony 2.1 (end-of-life since Nov 2013)
